### PR TITLE
Update for firmware 1.3.1

### DIFF
--- a/blue-app-helloperso/src/main.c
+++ b/blue-app-helloperso/src/main.c
@@ -377,7 +377,7 @@ unsigned char io_event(unsigned char channel) {
             // TODO perform actions after all screen elements have been
             // displayed
         } else {
-            UX_DISPLAY_PROCESSED_EVENT();
+            UX_DISPLAY_NEXT_ELEMENT();
         }
         break;
 

--- a/blue-app-helloworld/src/main.c
+++ b/blue-app-helloworld/src/main.c
@@ -278,7 +278,7 @@ unsigned char io_event(unsigned char channel) {
             // TODO perform actions after all screen elements have been
             // displayed
         } else {
-            UX_DISPLAY_PROCESSED_EVENT();
+            UX_DISPLAY_NEXT_ELEMENT();
         }
         break;
 

--- a/blue-app-samplesign/src/main.c
+++ b/blue-app-samplesign/src/main.c
@@ -585,7 +585,7 @@ unsigned char io_event(unsigned char channel) {
         } else {
             if (UX_DISPLAYED()) {
             } else {
-                UX_DISPLAY_PROCESSED_EVENT();
+                UX_DISPLAY_NEXT_ELEMENT();
             }
         }
         break;


### PR DESCRIPTION
Resolves error:
`/home/blue-sample-apps/blue-app-helloworld/src/main.c:281: undefined reference to UX_DISPLAY_PROCESSED_EVENT`

(Followed instructions at https://github.com/LedgerHQ/ledger-dev-doc/blob/master/nanos/setup.rst but I guess new SDK broke things. This should fix them.)

I have tested simply commenting out `UX_DISPLAY_PROCESSED_EVENT()` and compiling, the screen was blank when running the app. I looked through the libraries and `UX_DISPLAY_NEXT_ELEMENT()` looks very similar to what `UX_DISPLAY_PROCESSED_EVENT()` was. Tested uploading app with `UX_DISPLAY_NEXT_ELEMENT()` and I got the "Hello World" message successfully.